### PR TITLE
Display alignment timestamp on UI

### DIFF
--- a/dna/zomes/how/src/alignment.rs
+++ b/dna/zomes/how/src/alignment.rs
@@ -53,6 +53,7 @@ impl Alignment {
 pub struct AlignmentOutput {
     pub hash: EntryHashB64,
     pub content: Alignment,
+    pub header: Header,
 }
 
 
@@ -110,6 +111,7 @@ fn get_alignments_inner(base: EntryHash) -> HowResult<Vec<AlignmentOutput>> {
         alignments.push(AlignmentOutput {
             hash: h.entry_hash().unwrap().clone().into(),
             content: a,
+            header: h,
         });
     }
     Ok(alignments)

--- a/dna/zomes/how/tests/behaviors.rs
+++ b/dna/zomes/how/tests/behaviors.rs
@@ -81,6 +81,7 @@ pub async fn test_basics() {
         )
         .await;
     assert_eq!(alignments[1].hash, hash);
+    assert_eq!(alignments[1].header.author(), cell_alice.agent_pubkey());
     assert_eq!(alignments.len(), 2);
     debug!("{:#?}", alignments);
 

--- a/tests/src/how.ts
+++ b/tests/src/how.ts
@@ -69,9 +69,14 @@ export default async (orchestrator) => {
     const alignment1_hash = await alice_how.call('how', 'create_alignment', alignment1 );
     t.ok(alignment1_hash)
     console.log("alignment1_hash", alignment1_hash);
+    
 
     const alignments = await alice_how.call('how', 'get_alignments', null );
-    t.deepEqual(alignments, [{hash: alignments[0].hash, content: root}, {hash: alignment1_hash, content: alignment1}]);
+
+    t.deepEqual(alignments, [
+      {hash: alignments[0].hash, content: root, header: alignments[0].header}, 
+      {hash: alignment1_hash, content: alignment1, header: alignments[1].header}
+    ]);
 
     const tree = await alice_how.call('how', 'get_tree', null );
     console.log("Rust tree", tree);

--- a/ui/lib/src/elements/how-alignment.ts
+++ b/ui/lib/src/elements/how-alignment.ts
@@ -10,6 +10,7 @@ import {HowStore} from "../how.store";
 import { HowDocumentDialog } from "./how-document-dialog";
 import {ScopedElementsMixin} from "@open-wc/scoped-elements";
 import {ProfilesStore, profilesStoreContext,} from "@holochain-open-dev/profiles";
+import { Header } from "@holochain-open-dev/core-types";
 import {
   Button,
   Dialog,
@@ -36,6 +37,7 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
   _myProfile = new StoreSubscriber(this, () => this._profiles.myProfile);
   _knownProfiles = new StoreSubscriber(this, () => this._profiles.knownProfiles);
   _alignments = new StoreSubscriber(this, () => this._store.alignments);
+  _alignmentsHeader = new StoreSubscriber(this, () => this._store.alignmentsHeader);
   _documents = new StoreSubscriber(this, () => this._store.documents);
   _documentPaths = new StoreSubscriber(this, () => this._store.documentPaths);
 
@@ -57,6 +59,18 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
     }
     const alignment: Alignment = this._alignments.value[this.currentAlignmentEh];
     return alignment.parents.length > 0 ? `${alignment.parents[0]}.${alignment.path_abbreviation}` : alignment.path_abbreviation
+  }
+
+  getCreated(): string {
+    if (!this.currentAlignmentEh) {
+      return ''
+    }
+    const header: Header = this._alignmentsHeader.value[this.currentAlignmentEh];
+    const timestamp = header.timestamp as any
+    const date = new Date(timestamp / 1000)
+    console.log('header', header)
+    
+    return date.toLocaleString('en-us');
   }
 
   addDoc(document_type: string ) {
@@ -89,6 +103,7 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
     return html`
       <div class="alignment">
        <h4> ${alignment.short_name} </h4>
+       ${this.getCreated() ? html`<h5><i>Created: ${this.getCreated()}</i></h5>` : ""}
        <li> Parents: ${alignment.parents.map((path) => html`<span class="node-link" @click=${()=>this.handleNodelink(path)}>${path}</span>`)}</li>
        <li> Path Abbrev: ${alignment.path_abbreviation}</li>
        <li> Title: ${alignment.title}</li>

--- a/ui/lib/src/elements/how-controller.ts
+++ b/ui/lib/src/elements/how-controller.ts
@@ -50,6 +50,7 @@ export class HowController extends ScopedElementsMixin(LitElement) {
   _knownProfiles = new StoreSubscriber(this, () => this._profiles.knownProfiles);
   _alignments = new StoreSubscriber(this, () => this._store.alignments);
   _alignmentsPath = new StoreSubscriber(this, () => this._store.alignmentsPath);
+  _alignmentsHeader = new StoreSubscriber(this, () => this._store.alignmentsHeader);
 
   /** Private properties */
 

--- a/ui/lib/src/how.store.ts
+++ b/ui/lib/src/how.store.ts
@@ -1,4 +1,4 @@
-import { EntryHashB64, HeaderHashB64, AgentPubKeyB64, serializeHash } from '@holochain-open-dev/core-types';
+import { EntryHashB64, HeaderHashB64, AgentPubKeyB64, serializeHash, Header } from '@holochain-open-dev/core-types';
 import { CellClient } from '@holochain-open-dev/cell-client';
 import { writable, Writable, derived, Readable, get } from 'svelte/store';
 
@@ -30,6 +30,7 @@ export class HowStore {
   private alignmentsStore: Writable<Dictionary<Alignment>> = writable({});
   private documentsStore: Writable<Dictionary<Document>> = writable({});
   private alignmentsPathStore: Writable<Dictionary<string>> = writable({});
+  private alignmentsHeaderStore: Writable<Dictionary<Header>> = writable({});
   private treeStore: Writable<Node> = writable({val:{name:"T", alignments: [], documents: []}, children:[], id:"0"});
   private documentPathStore: Writable<Dictionary<Array<DocumentOutput>>> = writable({});
 
@@ -40,6 +41,7 @@ export class HowStore {
   public alignments: Readable<Dictionary<Alignment>> = derived(this.alignmentsStore, i => i)
   public documents: Readable<Dictionary<Document>> = derived(this.documentsStore, i => i)
   public alignmentsPath: Readable<Dictionary<string>> = derived(this.alignmentsPathStore, i => i)
+  public alignmentsHeader: Readable<Dictionary<Header>> = derived(this.alignmentsHeaderStore, i => i)  
   public tree: Readable<Node> = derived(this.treeStore, i => i)
   public documentPaths: Readable<Dictionary<Array<DocumentOutput>>> = derived(this.documentPathStore, i => i)
   public processes: Readable<Array<Process>> = derived(this.documents, d => this.getProcesses(get(this.treeStore)))
@@ -89,6 +91,10 @@ export class HowStore {
     const alignments = await this.service.getAlignments();
     for (const s of alignments) {
       this.updateAlignmentFromEntry(s.hash, s.content)
+      this.alignmentsHeaderStore.update(store => {
+        store[s.hash] = s.header
+        return store
+      })
     }
     return get(this.alignmentsStore)
   }

--- a/ui/lib/src/types.ts
+++ b/ui/lib/src/types.ts
@@ -1,6 +1,6 @@
 // TODO: add globally available interfaces for your elements
 
-import { EntryHashB64, AgentPubKeyB64 } from "@holochain-open-dev/core-types";
+import { EntryHashB64, AgentPubKeyB64, Header } from "@holochain-open-dev/core-types";
 import { createContext, Context } from "@lit-labs/context";
 import { HowStore } from "./how.store";
 
@@ -31,6 +31,7 @@ export interface Alignment {
 export interface AlignmentOutput {
   hash: EntryHashB64,
   content: Alignment,
+  header: Header,
 }
 
 export const DOC_TEMPLATE="_template"


### PR DESCRIPTION
@zippy There are some hiccups with Header.
I wish the DNA returns header with `create_alignment` method, so I can put that to frontend's store when creating new alignment, but I couldn't do that rust DNA update.

For now, It displays timestamp for only existing alignments but it displays empty for the new added one. 
Once you refresh the page, it'll display though.