### PR TITLE
Feature: Add modification date (timestamp) to Alignment

### DIFF
--- a/dna/zomes/how/src/alignment.rs
+++ b/dna/zomes/how/src/alignment.rs
@@ -53,6 +53,7 @@ impl Alignment {
 pub struct AlignmentOutput {
     pub hash: EntryHashB64,
     pub content: Alignment,
+    pub header: Header,
 }
 
 
@@ -110,6 +111,7 @@ fn get_alignments_inner(base: EntryHash) -> HowResult<Vec<AlignmentOutput>> {
         alignments.push(AlignmentOutput {
             hash: h.entry_hash().unwrap().clone().into(),
             content: a,
+            header: h,
         });
     }
     Ok(alignments)

--- a/dna/zomes/how/tests/behaviors.rs
+++ b/dna/zomes/how/tests/behaviors.rs
@@ -69,7 +69,7 @@ pub async fn test_basics() {
         meta: BTreeMap::new(),
     };
     
-    let hash: EntryHashB64 = conductor_alice
+    let alignment2_output: AlignmentOutput = conductor_alice
     .call(&cell_alice.zome("how"), "create_alignment", alignment2.clone())
     .await;
 
@@ -82,10 +82,10 @@ pub async fn test_basics() {
             (),
         )
         .await;
-    assert_eq!(alignments[1].hash, hash);
+    assert_eq!(alignments[1].hash, alignment2_output.hash);
     assert_eq!(alignments.len(), 2);
 
-    assert!(alignments[1].header);
+    assert_eq!(alignments[1].header, alignment2_output.header);
 
     debug!("{:#?}", alignments);
 

--- a/dna/zomes/how/tests/behaviors.rs
+++ b/dna/zomes/how/tests/behaviors.rs
@@ -82,6 +82,9 @@ pub async fn test_basics() {
         .await;
     assert_eq!(alignments[1].hash, hash);
     assert_eq!(alignments.len(), 2);
+
+    assert!(alignments[1].header);
+
     debug!("{:#?}", alignments);
 
     let content  = vec![("summary".to_string(), "blah blah".to_string())];

--- a/tests/src/how.ts
+++ b/tests/src/how.ts
@@ -68,14 +68,13 @@ export default async (orchestrator) => {
 
     await alice_how.call('how', 'initialize', {alignments: [root], documents:[document]} );
 
-    const alignment1_hash = await alice_how.call('how', 'create_alignment', alignment1 );
-    t.ok(alignment1_hash)
-    console.log("alignment1_hash", alignment1_hash);
+    const alignmentOutput = await alice_how.call('how', 'create_alignment', alignment1 );
+    t.ok(alignmentOutput)
 
     const alignments = await alice_how.call('how', 'get_alignments', null );
     const noHeaderAlignments = alignments.map(({ hash, content }) => ({ hash, content }));
 
-    t.deepEqual(noHeaderAlignments, [{hash: alignments[0].hash, content: root}, {hash: alignment1_hash, content: alignment1}]);
+    t.deepEqual(noHeaderAlignments, [{hash: alignments[0].hash, content: root}, {hash: alignmentOutput.hash, content: alignment1}]);
 
     t.ok(alignments[1].header);
 

--- a/tests/src/how.ts
+++ b/tests/src/how.ts
@@ -71,7 +71,11 @@ export default async (orchestrator) => {
     console.log("alignment1_hash", alignment1_hash);
 
     const alignments = await alice_how.call('how', 'get_alignments', null );
-    t.deepEqual(alignments, [{hash: alignments[0].hash, content: root}, {hash: alignment1_hash, content: alignment1}]);
+    const noHeaderAlignments = alignments.map(({ hash, content }) => ({ hash, content }));
+
+    t.deepEqual(noHeaderAlignments, [{hash: alignments[0].hash, content: root}, {hash: alignment1_hash, content: alignment1}]);
+
+    t.ok(alignments[1].header);
 
     const tree = await alice_how.call('how', 'get_tree', null );
     console.log("Rust tree", tree);

--- a/ui/lib/src/elements/how-alignment.ts
+++ b/ui/lib/src/elements/how-alignment.ts
@@ -101,8 +101,8 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
 
     const { summary = '' } = alignment;
 
-    const shouldTruncateSummary = this._fullSummaryVisible || summary.length < this._summaryMaxLength;
-    const formattedSummary = shouldTruncateSummary ? summary : `${summary.substr(0, this._summaryMaxLength)}...`;
+    const shouldTruncateSummary = !this._fullSummaryVisible && summary.length > this._summaryMaxLength;
+    const formattedSummary = shouldTruncateSummary ? `${summary.substr(0, this._summaryMaxLength)}...` : summary;
 
     /** Render layout */
     return html`
@@ -113,7 +113,7 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
        <li> Title: ${alignment.title}</li>
        <li> Summary: 
         <span>${formattedSummary}</span>
-        ${!shouldTruncateSummary ? html`<span class="node-link" @click=${() => this._fullSummaryVisible = true}>Show more</span>` : ''}
+        ${shouldTruncateSummary ? html`<span class="node-link" @click=${() => this._fullSummaryVisible = true}>Show more</span>` : ''}
       </li>
        <li> Stewards: ${alignment.stewards.map((agent: string)=>html`<span class="agent" title="${agent}">${this._knownProfiles.value[agent].nickname}</span>`)}</li>
        ${header?.timestamp ? html`<li> Created at: ${toLocaleDate(+header.timestamp)}</li>` : ''}

--- a/ui/lib/src/elements/how-alignment.ts
+++ b/ui/lib/src/elements/how-alignment.ts
@@ -35,7 +35,7 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
 
   _myProfile = new StoreSubscriber(this, () => this._profiles.myProfile);
   _knownProfiles = new StoreSubscriber(this, () => this._profiles.knownProfiles);
-  _alignments = new StoreSubscriber(this, () => this._store.alignments);
+  _alignmentOutputs = new StoreSubscriber(this, () => this._store.alignmentOutputs);
   _documents = new StoreSubscriber(this, () => this._store.documents);
   _documentPaths = new StoreSubscriber(this, () => this._store.documentPaths);
 
@@ -55,7 +55,7 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
     if (!this.currentAlignmentEh) {
       return ""
     }
-    const alignment: Alignment = this._alignments.value[this.currentAlignmentEh];
+    const alignment: Alignment = this._alignmentOutputs.value[this.currentAlignmentEh].content;
     return alignment.parents.length > 0 ? `${alignment.parents[0]}.${alignment.path_abbreviation}` : alignment.path_abbreviation
   }
 
@@ -68,12 +68,14 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
       return;
     }
     /** Get current alignment*/
-    const alignment: Alignment = this._alignments.value[this.currentAlignmentEh]
+    const { content: alignment, header } = this._alignmentOutputs.value[this.currentAlignmentEh]
 
     /** the list of documents for this alignment */
     const path = this.getPath()
     const docs = this._documentPaths.value[path]
     const documents = docs ? docs.map(doc => html`<b>${doc.content.document_type}</b>${doc.content.content.map(([key, value])=>html`<h3>${key}</h3><div>${value}</div>`)}`) : undefined
+
+    const toLocaleDate = (timestamp: number) => new Date(timestamp / 1000).toLocaleDateString()
 
     const processActions = []
     const processes = []
@@ -94,6 +96,7 @@ export class HowAlignment extends ScopedElementsMixin(LitElement) {
        <li> Title: ${alignment.title}</li>
        <li> Summary: ${alignment.summary}</li>
        <li> Stewards: ${alignment.stewards.map((agent: string)=>html`<span class="agent" title="${agent}">${this._knownProfiles.value[agent].nickname}</span>`)}</li>
+       ${header?.timestamp ? html`<li> Created at: ${toLocaleDate(+header.timestamp)}</li>` : ''}
        ${processes}
        <li> Documents:
         <ul>${documents} 

--- a/ui/lib/src/elements/how-controller.ts
+++ b/ui/lib/src/elements/how-controller.ts
@@ -111,6 +111,18 @@ export class HowController extends ScopedElementsMixin(LitElement) {
     });
   }
 
+  private handleDocumentClick = (event: MouseEvent) => {
+    if (!this.alignmentElem) {
+      return
+    }
+
+    const outsideClick = !event.composedPath().includes(this.alignmentElem)
+
+    if (this._currentAlignmentEh && outsideClick) {
+      this.handleAlignmentSelect('')
+    }
+  }
+
   async firstUpdated() {
     if (this.canLoadDummy) {
       await this.createDummyProfile()
@@ -475,6 +487,18 @@ export class HowController extends ScopedElementsMixin(LitElement) {
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback()
+
+    window.addEventListener('click', this.handleDocumentClick)
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback()
+
+    window.removeEventListener('click', this.handleDocumentClick)
+  }
+
   render() {
     return html`
 <!--  DRAWER -->
@@ -572,6 +596,7 @@ export class HowController extends ScopedElementsMixin(LitElement) {
         }
 
         .appBody {
+          min-height: 100vh;
           width: 100%;
           margin-top: 2px;
           display:flex;

--- a/ui/lib/src/elements/how-tree.ts
+++ b/ui/lib/src/elements/how-tree.ts
@@ -47,7 +47,7 @@ export class HowTree extends ScopedElementsMixin(LitElement) {
     const nodeId = this.getNodeId(node)
     return html`
     <li>
-      <span class="${nodeId == this.currentNode ? "current" : ""}" @click=${()=>this.select(nodeId)}>
+      <span class="${nodeId == this.currentNode ? "current" : ""}" @click=${(e: MouseEvent)=>{ e.stopPropagation(); this.select(nodeId) }}>
         ${node.id=="0" ? "Holochain Community Standards" : node.val.name} : ${node.val.documents.length}
         <mwc-button icon="add_circle" @click=${
           () => this.dispatchEvent(new CustomEvent('add-child', { detail: nodeId, bubbles: true, composed: true }))}>

--- a/ui/lib/src/how.service.ts
+++ b/ui/lib/src/how.service.ts
@@ -16,7 +16,7 @@ export class HowService {
     return this.callZome('initialize', input);
   }
 
-  async createAlignment(alignment: Alignment): Promise<EntryHashB64> {
+  async createAlignment(alignment: Alignment): Promise<AlignmentOutput> {
     return this.callZome('create_alignment', alignment);
   }
 

--- a/ui/lib/src/how.store.ts
+++ b/ui/lib/src/how.store.ts
@@ -196,20 +196,18 @@ export class HowStore {
   }
 
   async addAlignment(alignment: Alignment) : Promise<EntryHashB64> {
-    const alignmentEh: EntryHashB64 = await this.service.createAlignment(alignment)
+    const alignmentOutput: AlignmentOutput = await this.service.createAlignment(alignment)
+
+    const { hash } = alignmentOutput
 
     this.alignmentOutputsStore.update(alignmentOutputs => {
-      alignmentOutputs[alignmentEh] = {
-        hash: alignmentEh,
-        content: alignment,
-        header: {} as any,
-      };
+      alignmentOutputs[hash] = alignmentOutput
       
       return alignmentOutputs
     })
 
-    this.service.notify({alignmentHash:alignmentEh, message: {type:"NewAlignment", content:alignment}}, this.others());
-    return alignmentEh
+    this.service.notify({ alignmentHash: hash, message: { type:"NewAlignment", content:alignment }}, this.others());
+    return hash
   }
 
   async initilize(input: Initialization) : Promise<void> {

--- a/ui/lib/src/types.ts
+++ b/ui/lib/src/types.ts
@@ -1,6 +1,6 @@
 // TODO: add globally available interfaces for your elements
 
-import { EntryHashB64, AgentPubKeyB64 } from "@holochain-open-dev/core-types";
+import { EntryHashB64, AgentPubKeyB64, Header } from "@holochain-open-dev/core-types";
 import { createContext, Context } from "@lit-labs/context";
 import { HowStore } from "./how.store";
 
@@ -29,8 +29,9 @@ export interface Alignment {
 }
 
 export interface AlignmentOutput {
-  hash: EntryHashB64,
-  content: Alignment,
+  hash: EntryHashB64;
+  content: Alignment;
+  header: Header;
 }
 
 export const DOC_TEMPLATE="_template"


### PR DESCRIPTION
## Add modification date (timestamp) to Alignment

### Specs:
1. Update `AlignmentOutput` in `dna/zomes/how/src/alignment.rs` to include the entry `Header` that’s available in `get_alignments_inner()` from the `alignment_entries` `Vec`
2. Update tests with one simple assert to show that header info is returned from the zome call

- Cargo `dna/zomes/how/tests/behaviors.rs`
- tryorama `tests/src/how.ts`

3. Update `ui/lib/src/types.ts` to match the added Header on the Rust side
4. Update `ui/lib/src/elements/how-alignment.ts` to display the timestamp information